### PR TITLE
Sync TUF cache used for sigstore bundle verification

### DIFF
--- a/pkg/tuf/repo.go
+++ b/pkg/tuf/repo.go
@@ -302,7 +302,9 @@ var (
 // GetTrustedRoot returns the trusted root for the TUF repository.
 func GetTrustedRoot() (*root.TrustedRoot, error) {
 	now := time.Now().UTC()
-	if timestamp.IsZero() || timestamp.Before(now.Add(-24*time.Hour)) {
+	// check if timestamp has never been or if the current time is more
+	// than 24 hours after the current value of timestamp
+	if timestamp.IsZero() || now.After(timestamp.Add(24*time.Hour)) {
 		mu.Lock()
 		defer mu.Unlock()
 


### PR DESCRIPTION
Part of https://github.com/github/package-security/issues/1732

Update `GetTrustedRoot` to sync the TUF cache every 24 hours. I will look into threading the new `trustroot-resync-period` flag down to this function to the resync period is no longer hardcoded in a follow up.