### PR TITLE
Add signatureFormat in the conversion so that alpha1 and beta1 can be used

### DIFF
--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_conversion.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_conversion.go
@@ -89,6 +89,7 @@ func (matchResource *MatchResource) ConvertTo(_ context.Context, sink *v1beta1.M
 
 func (authority *Authority) ConvertTo(ctx context.Context, sink *v1beta1.Authority) error {
 	sink.Name = authority.Name
+	sink.SignatureFormat = authority.SignatureFormat
 	if authority.CTLog != nil && authority.CTLog.URL != nil {
 		sink.CTLog = &v1beta1.TLog{
 			URL:          authority.CTLog.URL.DeepCopy(),
@@ -244,6 +245,7 @@ func (spec *ClusterImagePolicySpec) ConvertFrom(ctx context.Context, source *v1b
 
 func (authority *Authority) ConvertFrom(ctx context.Context, source *v1beta1.Authority) error {
 	authority.Name = source.Name
+	authority.SignatureFormat = source.SignatureFormat
 	if source.CTLog != nil && source.CTLog.URL != nil {
 		authority.CTLog = &TLog{
 			URL:          source.CTLog.URL.DeepCopy(),


### PR DESCRIPTION
Without this, you cannot create a beta1 version of the clusterimagepolicies.policy.sigstore.dev  for github bundle validation.   ( SignatureFormat would revert to an empty value ).  

And worst, if you "kubectl edit" a clusterimagepolicies kubernetes would transform the alpha1 to beta1 for you to edit  and transform back beta1 to alpha1 to store. It means the signatureFormat is lost and you can have something working, editing a label and oups nothing is working anymore

