### PR TITLE
Fix shadowed trustedroot

### DIFF
--- a/pkg/tuf/repo.go
+++ b/pkg/tuf/repo.go
@@ -293,10 +293,9 @@ func ClientFromRemote(_ context.Context, mirror string, rootJSON []byte, targets
 }
 
 var (
-	mu                 sync.RWMutex
-	singletonRootError error
-	timestamp          time.Time
-	trustedRoot        *root.TrustedRoot
+	mu          sync.RWMutex
+	timestamp   time.Time
+	trustedRoot *root.TrustedRoot
 )
 
 // GetTrustedRoot returns the trusted root for the TUF repository.
@@ -311,19 +310,16 @@ func GetTrustedRoot(ctx context.Context) (*root.TrustedRoot, error) {
 
 		tufClient, err := tuf.NewFromEnv(context.Background())
 		if err != nil {
-			singletonRootError = fmt.Errorf("initializing tuf: %w", err)
-			return nil, singletonRootError
+			return nil, fmt.Errorf("initializing tuf: %w", err)
 		}
 		// TODO: add support for custom trusted root path
 		targetBytes, err := tufClient.GetTarget("trusted_root.json")
 		if err != nil {
-			singletonRootError = fmt.Errorf("error getting targets: %w", err)
-			return nil, singletonRootError
+			return nil, fmt.Errorf("error getting targets: %w", err)
 		}
 		trustedRoot, err = root.NewTrustedRootFromJSON(targetBytes)
 		if err != nil {
-			singletonRootError = fmt.Errorf("error creating trusted root: %w", err)
-			return nil, singletonRootError
+			return nil, fmt.Errorf("error creating trusted root: %w", err)
 		}
 
 		timestamp = now

--- a/pkg/tuf/repo.go
+++ b/pkg/tuf/repo.go
@@ -320,7 +320,7 @@ func GetTrustedRoot(ctx context.Context) (*root.TrustedRoot, error) {
 			singletonRootError = fmt.Errorf("error getting targets: %w", err)
 			return nil, singletonRootError
 		}
-		trustedRoot, err := root.NewTrustedRootFromJSON(targetBytes)
+		trustedRoot, err = root.NewTrustedRootFromJSON(targetBytes)
 		if err != nil {
 			singletonRootError = fmt.Errorf("error creating trusted root: %w", err)
 			return nil, singletonRootError


### PR DESCRIPTION
This code caused the singleton `trustedRoot` to be returned as nil on subsequent calls. The singleton was shadowed when the variable was redeclared in the `if` block:
```diff
-trustedRoot, err := root.NewTrustedRootFromJSON(targetBytes)
+trustedRoot, err = root.NewTrustedRootFromJSON(targetBytes)
```

Additionally, this PR removes some unused code managing a singleton error.

Fixes https://github.com/github/policy-controller/issues/177